### PR TITLE
Use more robust way to get the most recent tag

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -21,7 +21,8 @@ export function listTagNames(): string[] {
  * The latest reachable tag starting from HEAD
  */
 export function lastTag(): string {
-  return execa.sync("git", ["describe", "--abbrev=0", "--tags"]).stdout;
+  const ref = execa.sync("git", ["rev-list", "--tags", "--max-count=1"]).stdout;
+  return execa.sync("git", ["describe", "--tags", ref]).stdout;
 }
 
 export interface CommitListItem {


### PR DESCRIPTION
I've run in to this a lot on several repos setting up release-plan for the first time.

Most recently, on the repo for `esyes`. There was one prior tag, but `git describe --abbrev=0 --tags` could not find it, giving this error:
```
 stdout: 'Error: Command failed with exit code 128: git describe --abbrev=0 --tags\n' +
    "fatal: No tags can describe 'c37611084aa5f41f1ab7a357517e596dc5603cfd'.\n" +
    'Try --always, or create some tags.\n' +
    '    at makeError (/home/nvp/Development/OpenSource/starbeam/esyes/node_modules/.pnpm/execa@5.1.1/node_modules/execa/lib/error.js:60:11)\n' +
    '    at module.exports.sync (/home/nvp/Development/OpenSource/starbeam/esyes/node_modules/.pnpm/execa@5.1.1/node_modules/execa/index.js:194:17)\n' +
    '    at Object.lastTag (/home/nvp/Development/OpenSource/starbeam/esyes/node_modules/.pnpm/@ef4+lerna-changelog@2.0.0/node_modules/@ef4/lerna-changelog/lib/git.js:31:18)\n' +
```

I've found that this proposed technique for getting the most recent tag works better.
I've tested it across a variety of repos:
```bash
❯ git describe --tags `git rev-list --tags --max-count=1`
ember-primitives@0.10.1

❯ git describe --tags `git rev-list --tags --max-count=1`
v3.4.3-@embroider/compat

❯ git describe --tags `git rev-list --tags --max-count=1`
ember-resources@6.4.2

❯ git describe --tags `git rev-list --tags --max-count=1`
ember-repl@3.0.0-beta.7
```

when no tags are found, we get a non-zero exit:
```
❯ git describe --tags `git rev-list --tags --max-count=1`
fatal: No names found, cannot describe anything.

❯ echo $?
128
```