### PR TITLE
Add a default implementation for unlabelled

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -109,6 +109,10 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     };
   }
 
+  if (!wildcardLabel) {
+    wildcardLabel = `_github-changelog_unlabeled_`;
+  }
+
   if (wildcardLabel && !labels[wildcardLabel]) {
     labels[wildcardLabel] = "️:present: Additional updates";
   }


### PR DESCRIPTION
Things like release-plan require a section in the changelog that is "unlabelled" or "additional changes", but this wasn't turned on by default.

This PR changes the default and makes it add an unlabelled section without requiring config in your package.json 👍 