### PR TITLE
Do not generate changelog entries for private packages

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -51,7 +51,9 @@ function getPackages(rootPath: string): { name: string; path: string }[] {
   try {
     let { packages } = getPackagesSync(rootPath) as PackagesResult;
 
-    return packages.map(pkg => ({
+    let publishablePackages = packages.filter(pkg => !(pkg.packageJson as any)["private"]);
+
+    return publishablePackages.map(pkg => ({
       name: pkg.packageJson.name,
       path: pkg.dir,
     }));


### PR DESCRIPTION
Alternate to: https://github.com/embroider-build/release-plan/pull/60
(and more robust of an alternative than what's going on in that release-plan PR)

Resolves: https://github.com/embroider-build/create-release-plan-setup/issues/91

Try this out via:
```
"pnpm": {
  "overrides": {
    "@ef4/lerna-changelog": "github:embroider-build/github-changelog#dist/ignore-private-packgaes",
  }
}
```
or
```
"pnpm": {
  "overrides": {
    "@ef4/lerna-changelog": "github:embroider-build/github-changelog#3ad92f5",
  }
}
```
Example: https://github.com/NullVoxPopuli/limber/pull/1691

Outputted: https://github.com/NullVoxPopuli/limber/pull/1673
![image](https://github.com/embroider-build/github-changelog/assets/199018/5ce03fd5-03ba-485e-b75f-a23e4ac5306d)
