### PR TITLE
make errors getting issues non-fatal

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -169,8 +169,12 @@ export default class Changelog {
     await pMap(
       commitInfos,
       async (commitInfo: CommitInfo) => {
-        if (commitInfo.issueNumber) {
-          commitInfo.githubIssue = await this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
+        try {
+          if (commitInfo.issueNumber) {
+            commitInfo.githubIssue = await this.github.getIssueData(this.config.repo, commitInfo.issueNumber);
+          }
+        } catch (err: any) {
+          console.error(`Error getting issue data: ${err.message}`);
         }
 
         progressBar.tick();

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -65,7 +65,12 @@ export default class GithubAPI {
     if (res.ok) {
       return parsedResponse;
     }
-    throw new ConfigurationError(`Fetch error: ${res.statusText}.\n${JSON.stringify(parsedResponse)}`);
+
+    if (res.status === 404) {
+      throw new ConfigurationError(`Not Found [${url}]`);
+    }
+
+    throw new ConfigurationError(`Fetch error [${url}]: ${res.statusText}.\n${JSON.stringify(parsedResponse)}`);
   }
 
   private getAuthToken(): string {


### PR DESCRIPTION
This can happen if someone moves a repo between the previous merge and then a release. The Issue number is the only thing that is used to get issue details but the full path should be used (if at all possible). 

This change just prevents this situation from causing an unrecoverable error and may not be the best thing to do 🤷 It's a pretty rare case so it could be nice just not to block people. Thoughs? 