### PR TITLE
Apply ignoreCommitters config to PR creators

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -203,7 +203,10 @@ export default class Changelog {
           releaseMap[currentTag] = { name: currentTag, date, commits: [] };
         }
 
-        releaseMap[currentTag].commits.push(commit);
+        let prUserLogin = commit.githubIssue?.user.login;
+        if (prUserLogin && !this.ignoreCommitter(prUserLogin)) {
+          releaseMap[currentTag].commits.push(commit);
+        }
       }
     }
 

--- a/src/functional/__snapshots__/markdown-full.spec.ts.snap
+++ b/src/functional/__snapshots__/markdown-full.spec.ts.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`createMarkdown ignore config ignores PRs from bot users even if they were not the (merge) committer 1`] = `
+"
+## Unreleased (2099-01-01)
+
+#### :rocket: New Feature
+* \`the-force-awakens\`, \`rogue-one\`
+  * [#7](https://github.com/embroider-build/github-changelog/pull/7) feat: that is not how the Force works! ([@han-solo](https://github.com/han-solo))
+
+#### :nail_care: Enhancement
+* \`the-force-awakens\`, \`rogue-one\`
+  * [#7](https://github.com/embroider-build/github-changelog/pull/7) feat: that is not how the Force works! ([@han-solo](https://github.com/han-solo))
+
+#### Committers: 1
+- Han Solo ([@han-solo](https://github.com/han-solo))
+
+
+## v6.0.0 (1983-05-25)
+
+#### :rocket: New Feature
+* \`return-of-the-jedi\`
+  * [#5](https://github.com/embroider-build/github-changelog/pull/5) feat: I am your father ([@vader](https://github.com/vader))
+
+#### :bug: Bug Fix
+* \`return-of-the-jedi\`
+  * [#4](https://github.com/embroider-build/github-changelog/pull/4) fix: RRRAARRWHHGWWR ([@chewbacca](https://github.com/chewbacca))
+
+#### :nail_care: Enhancement
+* \`return-of-the-jedi\`
+  * [#6](https://github.com/embroider-build/github-changelog/pull/6) refactor: he is my brother ([@princess-leia](https://github.com/princess-leia))
+
+#### :house: Maintenance
+* \`return-of-the-jedi\`
+  * [#4](https://github.com/embroider-build/github-changelog/pull/4) fix: RRRAARRWHHGWWR ([@chewbacca](https://github.com/chewbacca))
+
+#### Committers: 3
+- Chwebacca ([@chewbacca](https://github.com/chewbacca))
+- Darth Vader ([@vader](https://github.com/vader))
+- Princess Leia Organa ([@princess-leia](https://github.com/princess-leia))
+
+
+## v5.0.0 (1980-05-17)
+
+#### :boom: Breaking Change
+* \`empire-strikes-back\`
+  * [#2](https://github.com/embroider-build/github-changelog/pull/2) chore: Terminate her... immediately! ([@gtarkin](https://github.com/gtarkin))
+
+#### :bug: Bug Fix
+* \`empire-strikes-back\`
+  * [#3](https://github.com/embroider-build/github-changelog/pull/3) fix: Get me the rebels base! ([@vader](https://github.com/vader))
+
+#### Committers: 2
+- Darth Vader ([@vader](https://github.com/vader))
+- Governor Tarkin ([@gtarkin](https://github.com/gtarkin))
+
+
+## v4.0.0 (1977-05-25)
+
+#### :rocket: New Feature
+* \`a-new-hope\`
+  * [#1](https://github.com/embroider-build/github-changelog/pull/1) feat: May the force be with you ([@luke](https://github.com/luke))
+
+#### Committers: 1
+- Luke Skywalker ([@luke](https://github.com/luke))"
+`;
+
 exports[`createMarkdown multiple tags outputs correct changelog 1`] = `
 "
 ## a-new-hope@4.0.0 (1977-05-25)
@@ -42,7 +107,12 @@ exports[`createMarkdown single project outputs correct changelog 1`] = `
 #### :nail_care: Enhancement
 * [#7](https://github.com/embroider-build/github-changelog/pull/7) feat: that is not how the Force works! ([@han-solo](https://github.com/han-solo))
 
-#### Committers: 1
+#### :house: Maintenance
+* \`return-of-the-jedi\`
+  * This is the commit title for the issue (#8) ([@bot-user](https://github.com/bot-user))
+
+#### Committers: 2
+- Bot User ([@bot-user](https://github.com/bot-user))
 - Han Solo ([@han-solo](https://github.com/han-solo))
 
 
@@ -100,7 +170,12 @@ exports[`createMarkdown single tags outputs correct changelog 1`] = `
 * \`the-force-awakens\`, \`rogue-one\`
   * [#7](https://github.com/embroider-build/github-changelog/pull/7) feat: that is not how the Force works! ([@han-solo](https://github.com/han-solo))
 
-#### Committers: 1
+#### :house: Maintenance
+* \`return-of-the-jedi\`
+  * This is the commit title for the issue (#8) ([@bot-user](https://github.com/bot-user))
+
+#### Committers: 2
+- Bot User ([@bot-user](https://github.com/bot-user))
 - Han Solo ([@han-solo](https://github.com/han-solo))
 
 


### PR DESCRIPTION
I was seeing PRs made by renovatebot, but manually merged using a merge commit strategy as not being ignored from a release. This should fix that.