### PR TITLE
only process commits on the current branch

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -55,6 +55,7 @@ export function listCommits(from: string, to: string = ""): CommitListItem[] {
       "--oneline",
       "--pretty=hash<%h> ref<%D> message<%s> date<%cd>",
       "--date=short",
+      "--first-parent",
       `${from}..${to}`,
     ])
     .stdout.split("\n")


### PR DESCRIPTION
This is to cater for the situation where people do a number of PRs (maybe from forks) to a PR before it is merged. In that situation it's not exactly clear what the PR number means so ignoring those commits is simpler for everyone