### PR TITLE
Fix issue with similarly named packages matching the wrong package in the generated changelog.

### DIFF
--- a/src/changelog.spec.ts
+++ b/src/changelog.spec.ts
@@ -54,6 +54,33 @@ describe("Changelog", () => {
     }
   });
 
+  describe("packageFromPath with similarly named packages", () => {
+    const MockedChangelog = require("./changelog").default;
+
+    const TESTS = [
+      ["", ""],
+      ["/ember-fastboot", "ember-fastboot"],
+      ["/ember-fastboot-2-fast-2-furious", "ember-fastboot-2-fast-2-furious"],
+      ["/ember-fastboot-2-fast-2-furious/package.json", "ember-fastboot-2-fast-2-furious"],
+      ["/ember-fastboot-tokyo-drift", "ember-fastboot-tokyo-drift"],
+      ["/ember-fastboot-tokyo-drift/package.json", "ember-fastboot-tokyo-drift"],
+    ];
+
+    for (let [input, expected] of TESTS) {
+      it(`${input} -> ${expected}`, () => {
+        const changelog = new MockedChangelog({
+          rootPath: "/",
+          packages: [
+            { name: "ember-fastboot", path: "/ember-fastboot" },
+            { name: "ember-fastboot-2-fast-2-furious", path: "/ember-fastboot-2-fast-2-furious" },
+            { name: "ember-fastboot-tokyo-drift", path: "/ember-fastboot-tokyo-drift" },
+          ],
+        });
+        expect(changelog.packageFromPath(input)).toEqual(expected);
+      });
+    }
+  });
+
   describe("getCommitInfos", () => {
     beforeEach(() => {
       require("./fetch").__resetMockResponses();

--- a/src/changelog.spec.ts
+++ b/src/changelog.spec.ts
@@ -59,10 +59,8 @@ describe("Changelog", () => {
 
     const TESTS = [
       ["", ""],
-      ["/ember-fastboot", "ember-fastboot"],
-      ["/ember-fastboot-2-fast-2-furious", "ember-fastboot-2-fast-2-furious"],
+      ["/ember-fastboot/package.json", "ember-fastboot"],
       ["/ember-fastboot-2-fast-2-furious/package.json", "ember-fastboot-2-fast-2-furious"],
-      ["/ember-fastboot-tokyo-drift", "ember-fastboot-tokyo-drift"],
       ["/ember-fastboot-tokyo-drift/package.json", "ember-fastboot-tokyo-drift"],
     ];
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -91,21 +91,17 @@ export default class Changelog {
       // ember-fastboot-2-fast-2-furious
       //
       // in this case, we can't short circuit with length === 1, but we can do a longer match
-      const packageCandidates = this.config.packages.filter(p => absolutePath.startsWith(p.path));
+      const foundPackage = this.config.packages.find(p => {
+        let withSlash = p.path.endsWith("/") ? p.path : `${p.path}/`;
 
-      if (packageCandidates.length === 1) {
-        return packageCandidates[0].name;
+        return absolutePath.startsWith(withSlash);
+      });
+
+      if (foundPackage) {
+        return foundPackage.name;
       }
 
-      let longestMatch = "";
-
-      for (let pkg of packageCandidates) {
-        if (pkg.name.length > longestMatch.length) {
-          longestMatch = pkg.name;
-        }
-      }
-
-      return longestMatch; // may be empty if 0 candidates exist
+      return "";
     } else {
       // if we did not find any packages then default to
       const parts = path.split("/");

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,5 +1,5 @@
 const pMap = require("p-map");
-const { resolve } = require("path");
+const { resolve, sep } = require("path");
 
 import progressBar from "./progress-bar";
 import { Configuration } from "./configuration";
@@ -89,10 +89,8 @@ export default class Changelog {
       // Sometimes multiple packages may exist with the same prefix:
       // ember-fastboot
       // ember-fastboot-2-fast-2-furious
-      //
-      // in this case, we can't short circuit with length === 1, but we can do a longer match
       const foundPackage = this.config.packages.find(p => {
-        let withSlash = p.path.endsWith("/") ? p.path : `${p.path}/`;
+        let withSlash = p.path.endsWith(sep) ? p.path : `${p.path}${sep}`;
 
         return absolutePath.startsWith(withSlash);
       });


### PR DESCRIPTION
See tests for examples.

tl;dr: if you have two packages, `ember-scoped-css` and `ember-scoped-css-compat`, and make a change to only `ember-scoped-css-compat`, the changelog will say that the change came from `ember-scoped-css`, becasue `ember-scoped-css-compat` _startsWith_ `ember-scoped-css` -- so we need to do a "longest match" check if we have multiple startsWith matches.