### PR TITLE
Ignore pre release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "prettier --write 'src/**/*.ts'",
     "test": "vitest",
     "test-ci": "pnpm build && pnpm test",
-    "watch": "pnpm build -- --watch"
+    "watch": "pnpm build --watch"
   },
   "prettier": {
     "arrowParens": "avoid",
@@ -48,10 +48,12 @@
     "make-fetch-happen": "^9.0.0",
     "p-map": "^3.0.0",
     "progress": "^2.0.0",
+    "semver": "^7.7.2",
     "yargs": "^17.1.0"
   },
   "devDependencies": {
     "@types/node": "22.10.10",
+    "@types/semver": "^7.7.0",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "eslint": "8.55.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       progress:
         specifier: ^2.0.0
         version: 2.0.3
+      semver:
+        specifier: ^7.7.2
+        version: 7.7.2
       yargs:
         specifier: ^17.1.0
         version: 17.7.2
@@ -42,6 +45,9 @@ importers:
       '@types/node':
         specifier: 22.10.10
         version: 22.10.10
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.0
       '@typescript-eslint/eslint-plugin':
         specifier: 5.62.0
         version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.55.0)(typescript@5.0.4))(eslint@8.55.0)(typescript@5.0.4)
@@ -494,8 +500,8 @@ packages:
   '@types/node@22.10.10':
     resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
 
-  '@types/semver@7.5.8':
-    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+  '@types/semver@7.7.0':
+    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@typescript-eslint/eslint-plugin@5.62.0':
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
@@ -1454,8 +1460,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1932,7 +1938,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/git@5.0.8':
     dependencies:
@@ -1943,7 +1949,7 @@ snapshots:
       proc-log: 4.2.0
       promise-inflight: 1.0.1
       promise-retry: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       which: 4.0.0
     transitivePeerDependencies:
       - bluebird
@@ -1961,7 +1967,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 6.0.2
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - bluebird
 
@@ -2132,7 +2138,7 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
-  '@types/semver@7.5.8': {}
+  '@types/semver@7.7.0': {}
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.55.0)(typescript@5.0.4))(eslint@8.55.0)(typescript@5.0.4)':
     dependencies:
@@ -2146,7 +2152,7 @@ snapshots:
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare-lite: 1.4.0
-      semver: 7.7.1
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.0.4)
     optionalDependencies:
       typescript: 5.0.4
@@ -2191,7 +2197,7 @@ snapshots:
       debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.1
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.0.4)
     optionalDependencies:
       typescript: 5.0.4
@@ -2202,13 +2208,13 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.55.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
+      '@types/semver': 7.7.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
       eslint: 8.55.0
       eslint-scope: 5.1.1
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2974,12 +2980,12 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   npm-install-checks@6.3.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-normalize-package-bin@3.0.1: {}
 
@@ -2987,7 +2993,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-name: 5.0.1
 
   npm-pick-manifest@9.1.0:
@@ -2995,7 +3001,7 @@ snapshots:
       npm-install-checks: 6.3.0
       npm-normalize-package-bin: 3.0.1
       npm-package-arg: 11.0.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   npm-run-path@4.0.1:
     dependencies:
@@ -3043,7 +3049,7 @@ snapshots:
       ky: 1.7.5
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
-      semver: 7.7.1
+      semver: 7.7.2
 
   parent-module@1.0.1:
     dependencies:
@@ -3145,7 +3151,7 @@ snapshots:
       js-yaml: 4.1.0
       latest-version: 9.0.0
       parse-github-repo-url: 1.4.1
-      semver: 7.7.1
+      semver: 7.7.2
       yargs: 17.7.2
     transitivePeerDependencies:
       - bluebird
@@ -3195,7 +3201,7 @@ snapshots:
   safer-buffer@2.1.2:
     optional: true
 
-  semver@7.7.1: {}
+  semver@7.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -8,6 +8,7 @@ import * as Git from "./git";
 import GithubAPI, { GitHubUserResponse } from "./github-api";
 import { CommitInfo, Release } from "./interfaces";
 import MarkdownRenderer from "./markdown-renderer";
+import { prerelease } from "semver";
 
 const UNRELEASED_TAG = "___unreleased___";
 
@@ -158,7 +159,8 @@ export default class Changelog {
         tagsInCommit = refName
           .split(", ")
           .filter(ref => ref.startsWith(TAG_PREFIX))
-          .map(ref => ref.substr(TAG_PREFIX.length));
+          .map(ref => ref.substr(TAG_PREFIX.length))
+          .filter(ref => !prerelease(ref));
       }
 
       const issueNumber = findPullRequestId(message);

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,7 +21,7 @@ export function listTagNames(): string[] {
  * The latest reachable tag starting from HEAD
  */
 export function lastTag(): string {
-  return execa.sync("git", ["describe", "--abbrev=0", "--tags"]).stdout;
+  return execa.sync("git", ["describe", "--abbrev=0", "--tags", "--first-parent"]).stdout;
 }
 
 export interface CommitListItem {

--- a/src/git.ts
+++ b/src/git.ts
@@ -55,7 +55,6 @@ export function listCommits(from: string, to: string = ""): CommitListItem[] {
       "--oneline",
       "--pretty=hash<%h> ref<%D> message<%s> date<%cd>",
       "--date=short",
-      "--first-parent",
       `${from}..${to}`,
     ])
     .stdout.split("\n")


### PR DESCRIPTION
I'm trying to figure out what release-plan should be doing when it comes rolling up beta releases.

This is my first attempt at changing the semantics of github-changelog so that it does the right thing. This will obviously need some discussion and will also probably need some sort of configuration 🤔 