### PR TITLE
Fix tag and commit detection

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -21,7 +21,7 @@ export function listTagNames(): string[] {
  * The latest reachable tag starting from HEAD
  */
 export function lastTag(): string {
-  return execa.sync("git", ["describe", "--abbrev=0", "--tags"]).stdout;
+  return execa.sync("git", ["describe", "--abbrev=0", "--tags", "--first-parent"]).stdout;
 }
 
 export interface CommitListItem {

--- a/src/git.ts
+++ b/src/git.ts
@@ -55,7 +55,6 @@ export function listCommits(from: string, to: string = ""): CommitListItem[] {
       "--oneline",
       "--pretty=hash<%h> ref<%D> message<%s> date<%cd>",
       "--date=short",
-      "--first-parent",
       `${from}..${to}`,
     ])
     .stdout.split("\n")

--- a/tests/basic-acceptance.test.js
+++ b/tests/basic-acceptance.test.js
@@ -6,6 +6,8 @@ if (!process.env.GITHUB_AUTH) {
   console.warn("Warning: to run all tests you need to provide a GITHUB_AUTH");
 }
 
+const todaysDate = new Date().toISOString().split("T")[0];
+
 describe.skipIf(!process.env.GITHUB_AUTH)("command line interface", () => {
   it("can produce a result", async () => {
     const { stdout } =
@@ -13,7 +15,7 @@ describe.skipIf(!process.env.GITHUB_AUTH)("command line interface", () => {
 
     expect(stdout).toMatchInlineSnapshot(`
       "
-      ## Unreleased (2025-07-31)
+      ## Unreleased (${todaysDate})
 
       #### :rocket: Enhancement
       * \`github-changelog\`
@@ -40,7 +42,7 @@ describe.skipIf(!process.env.GITHUB_AUTH)("command line interface", () => {
 
     expect(stdout).toMatchInlineSnapshot(`
       "
-      ## Unreleased (2025-07-31)
+      ## Unreleased (${todaysDate})
 
       #### :rocket: Enhancement
       * \`github-changelog\`


### PR DESCRIPTION
This PR fixes 2 things: 

- it only tries to detect tags on the current branch. This can help if you're trying to make a changelog on multiple branches in a repo
- it discovers **all commits** since the last tag even if those commits are on different branches. This helps to detect pull requests merged to other branches that are then merged into the branch you're generating a changelog for