### PR TITLE
fix issue where nested package structures aren't reported correctly

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -55,12 +55,20 @@ function getPackages(rootPath: string): { name: string; path: string }[] {
   try {
     let { packages } = getPackagesSync(rootPath) as PackagesResult;
 
-    return packages
+    let result = packages
       .filter(pkg => !pkg.packageJson.private)
       .map(pkg => ({
         name: pkg.packageJson.name,
         path: pkg.dir,
       }));
+
+    /**
+     * The fixes the case where you have a root package and packages in some sub-folder. We always
+     * want other systems to match on longer package paths first so that you find the right leaf
+     * package when building a changelog.
+     */
+    result.sort((a, b) => b.path.length - a.path.length);
+    return result;
   } catch (e) {
     // Pre-existing lerna-changelog (from before the fork) behavior returns []
     // when something goes wrong with package discovery.


### PR DESCRIPTION
I noticed this when doing the ember-cli release. We now have ember-cli at the root location of the monorepo `.` and a number of packages under `packages/*` and the changelog was reporting the wrong thing

https://github.com/ember-cli/ember-cli/pull/10797